### PR TITLE
Copy lvalues instead of referencing them

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -192,7 +192,7 @@ namespace FunctorTest
 {
 	struct Functor
 	{
-		int val = 0;
+		int &val;
 		void operator()(int x)
 		{
 			val += x;
@@ -201,11 +201,12 @@ namespace FunctorTest
 
 	void test()
 	{
-		Functor o;
+		int val = 0;
+		Functor o{val};
 		signal<void(int)> sig;
 		sig.connect(o);
 		sig(10);
-		assert(o.val == 10);
+		assert(val == 10);
 	}
 }
 
@@ -248,6 +249,7 @@ void test()
 			foo.sig(1.f);
 			assert(bar1.total == 2);
 			assert(bar3->total == 2);
+			delete bar3;
 		}
 		foo.sig(1.f);
 	}


### PR DESCRIPTION
If it is of interest, I've made an attempt at resolving #20. I can't say I'm 100% confident in this code, but the basic test suite passes (with address/undefined behavior sanitizers). Thanks!

signal::connect has been reworked. It now does one of the following 3:
* Stores a function pointer if the callable can be converted to one
* Constructs the callable in the pointer's memory via perfect forwarding
* Constructs the callable on the heap via perfect forwarding

One relevant test in main.cpp has been updated, and a memory leak in another
test was fixed.

Also marks conn_nontrivial destructor as an override